### PR TITLE
Wrap path in single quotes

### DIFF
--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -35,7 +35,7 @@ function M.quartoPreview()
     cmd = 'quarto preview'
   else
     mode = "file"
-    cmd = 'quarto preview ' .. buffer_path
+    cmd = 'quarto preview \'' .. buffer_path .. '\''
   end
 
   local quarto_extensions = { ".qmd", ".Rmd", ".ipynb", ".md" }


### PR DESCRIPTION
Hi,

I tried to use this plugin but encountered an error in the `:QuartoPreview` command. The error message was:

`ERROR: /Users/felix is not a project`

The path of the file I tried to preview is /Users/felix 1/test/test.qmd so I thought the problem might be the whitespace in the file path. I know that whitespaces in paths are suboptimal but macOS did that automatically when I moved to a new machine years ago so I guess I am not the only one with that problem. Furthermore, it seems quite a hassle to change the path of a given user's home directory on macOS so I would prefer not to do that for now.

Luckily, the fix is pretty simple. I just wrapped the path in quotes such that the shell recognizes the entire file path.

Thanks for your work on this! Now that the plugin works for me, I find it really cool!