### PR TITLE
Add group for autocmd.

### DIFF
--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -138,6 +138,8 @@ M.setup = function(opt)
 
   api.nvim_create_autocmd({ "BufEnter" }, {
     pattern = { "*.qmd" },
+    group = vim.api.nvim_create_augroup('QuartoSetup', {}),
+    desc = 'set up quarto',
     callback = function()
       if M.config.lspFeatures.enabled and vim.bo.buftype ~= 'terminal' then
         M.activate()


### PR DESCRIPTION
Creating augroup for all autocmds is considered as best practice.