### PR TITLE
fix: quarto preview in Windows/PowerShell

### DIFF
--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -37,7 +37,11 @@ function M.quartoPreview()
     cmd = 'quarto preview'
   else
     mode = "file"
-    cmd = 'quarto preview \'' .. buffer_path .. '\''
+    if vim.loop.os_uname().sysname == "Windows_NT" then
+      cmd = 'quarto preview \\"' .. buffer_path .. '\\"'
+    else
+      cmd = 'quarto preview \'' .. buffer_path .. '\''
+    end
   end
 
   local quarto_extensions = { ".qmd", ".Rmd", ".ipynb", ".md" }


### PR DESCRIPTION
Fixes #34. This appears to be a Windows/PowerShell-specific issue so I try to contain this to just Windows. I change how file paths passed to `quartoPreview()` are handled to resolve the issue while still accounting for spaces in the file path. Let me know what you think.