### PR TITLE
Pass arguments to quarto preview

### DIFF
--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -34,10 +34,10 @@ M.defaultConfig = {
 -- use defaultConfig if not setup
 M.config = M.defaultConfig
 
-function M.quartoPreview(arg)
-  if not (type(arg) == "string") then
-    arg = ''
-  end
+function M.quartoPreview(opts)
+  opts = opts or {}
+  local args = opts.args or ''
+
   -- find root directory / check if it is a project
   local buffer_path = api.nvim_buf_get_name(0)
   local root_dir = util.root_pattern("_quarto.yml")(buffer_path)
@@ -45,13 +45,13 @@ function M.quartoPreview(arg)
   local mode
   if root_dir then
     mode = "project"
-    cmd = 'quarto preview' .. ' ' .. arg
+    cmd = 'quarto preview' .. ' ' .. args
   else
     mode = "file"
     if vim.loop.os_uname().sysname == "Windows_NT" then
-      cmd = 'quarto preview \\"' .. buffer_path .. '\\"' .. ' ' ..  arg
+      cmd = 'quarto preview \\"' .. buffer_path .. '\\"' .. ' ' ..  args
     else
-      cmd = 'quarto preview \'' .. buffer_path .. '\'' .. ' ' .. arg
+      cmd = 'quarto preview \'' .. buffer_path .. '\'' .. ' ' .. args
     end
   end
 

--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -34,7 +34,10 @@ M.defaultConfig = {
 -- use defaultConfig if not setup
 M.config = M.defaultConfig
 
-function M.quartoPreview()
+function M.quartoPreview(arg)
+  if not (type(arg) == "string") then
+    arg = ''
+  end
   -- find root directory / check if it is a project
   local buffer_path = api.nvim_buf_get_name(0)
   local root_dir = util.root_pattern("_quarto.yml")(buffer_path)
@@ -42,13 +45,13 @@ function M.quartoPreview()
   local mode
   if root_dir then
     mode = "project"
-    cmd = 'quarto preview'
+    cmd = 'quarto preview' .. ' ' .. arg
   else
     mode = "file"
     if vim.loop.os_uname().sysname == "Windows_NT" then
-      cmd = 'quarto preview \\"' .. buffer_path .. '\\"'
+      cmd = 'quarto preview \\"' .. buffer_path .. '\\"' .. ' ' ..  arg
     else
-      cmd = 'quarto preview \'' .. buffer_path .. '\''
+      cmd = 'quarto preview \'' .. buffer_path .. '\'' .. ' ' .. arg
     end
   end
 

--- a/plugin/quarto.lua
+++ b/plugin/quarto.lua
@@ -16,7 +16,7 @@ end
 local quarto = require 'quarto'
 local api = vim.api
 
-api.nvim_create_user_command('QuartoPreview', quarto.quartoPreview, {})
+api.nvim_create_user_command('QuartoPreview', quarto.quartoPreview, {nargs = '*'})
 api.nvim_create_user_command('QuartoClosePreview', quarto.quartoClosePreview, {})
 api.nvim_create_user_command('QuartoActivate', quarto.activate, {})
 api.nvim_create_user_command('QuartoHelp', quarto.searchHelp, { nargs = 1 })


### PR DESCRIPTION
Can we add arguments to apis and pass them to the quarto commands? Needed this to call quarto preview with '--no-browser' when I am sshed into remote servers and don't want quarto to open up a x11 window of a browser from the remote.