### PR TITLE
Code Runner Overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ require('quarto').setup({
     },
     codeRunner = {
       enabled = false,
-      default_method = nil, -- 'molten-nvim' or 'vim-slime'
-      ft_runners = {}, -- filetype to runner, ie. `{ python = "molten-nvim" }`.
-                     -- Takes precedence over `default_method`
+      default_method = nil, -- 'molten' or 'slime'
+      ft_runners = {}, -- filetype to runner, ie. `{ python = "molten" }`.
+                       -- Takes precedence over `default_method`
       never_run = { "yaml" }, -- filetypes which are never sent to a code runner
     },
     completion = {
@@ -180,9 +180,9 @@ will work with:
 I recommend picking a code runner, setting it up based on its README, and then coming back
 to this point to learn how Quarto will augment that code runner.
 
-This plugin enables easily sending code cells to your code runner. This is exposed to the user in
-two different ways: commands, covered below; and lua functions, covered right here. *By default
-these functions will only run cells that are the same language as the current cell.*
+This plugin enables easily sending code cells to your code runner. There are two different ways to
+do this: commands, covered below; and lua functions, covered right here. *By default these functions
+will only run cells that are the same language as the current cell.*
 
 Quarto exposes code running functions through to runner module: `require('quarto.runner')`. Those
 functions are:
@@ -202,11 +202,11 @@ current cell.
 Here are some example run mappings:
 ```lua
 local runner = require("quarto.runner")
-vim.keymap.set("n", "<localleader>rc", runner.run_cell, { desc = "run cell", silent = true })
+vim.keymap.set("n", "<localleader>rc", runner.run_cell,  { desc = "run cell", silent = true })
 vim.keymap.set("n", "<localleader>ra", runner.run_above, { desc = "run cell and above", silent = true })
-vim.keymap.set("n", "<localleader>rA", runner.run_all, { desc = "run all cells", silent = true })
-vim.keymap.set("n", "<localleader>rl", runner.run_line, { desc = "run line", silent = true })
-vim.keymap.set("v", "<localleader>r", runner.run_range, { desc = "run line", silent = true })
+vim.keymap.set("n", "<localleader>rA", runner.run_all,   { desc = "run all cells", silent = true })
+vim.keymap.set("n", "<localleader>rl", runner.run_line,  { desc = "run line", silent = true })
+vim.keymap.set("v", "<localleader>r",  runner.run_range, { desc = "run line", silent = true })
 vim.keymap.set("n", "<localleader>RA", function()
   runner.run_all(true)
 end, { desc = "run all cells of all languages", silent = true })

--- a/README.md
+++ b/README.md
@@ -167,6 +167,52 @@ Other languages might have similar issues (e.g. I see a lot of warnings about wh
 If you come across them and have a fix, I will be very happy about a pull request!
 Or, what might ultimately be the cleaner way of documenting language specific issues, an entry in the [wiki](https://github.com/quarto-dev/quarto-nvim/wiki).
 
+## Running Code
+
+Quarto-nvim doesn't run code for you, instead, it will interface with existing code running
+plugins and tell them what to run. There are currently two such code running plugins that quarto
+will work with:
+1. [molten-nvim](https://github.com/benlubas/molten-nvim) - a code runner that supports the jupyter
+   kernel, renders output below each code cell, and optionally renders images in the terminal.
+2. [vim-slime](https://github.com/jpalardy/vim-slime) - a general purpose code runner with support
+   for sending code to integrated nvim terminals, tmux panes, and many others.
+
+I recommend picking a code runner, setting it up based on its README, and then coming back
+to this point to learn how Quarto will augment that code runner.
+
+This plugin enables easily sending code cells to your code runner. This is exposed to the user in
+two different ways: commands, covered below; and lua functions, covered right here. *By default
+these functions will only run cells that are the same language as the current cell.*
+
+Quarto exposes code running functions through to runner module: `require('quarto.runner')`. Those
+functions are:
+- `run_cell()` - runs the current cell
+- `run_above(multi_lang)` - runs all the cells above the current one, **and** the current one, in order
+- `run_below(multi_lang)` - runs all the cells below the current one, **and** the current one, in order
+- `run_all(multi_lang)` - runs all the cells in the document
+- `run_line(multi_lang)` - runs the line of code at your cursor
+- `run_range()` - run code inside the visual range
+
+Each function that takes the optional `multi_lang` argument will run cells of all languages when
+called with the value `true`, and will only run cells that match the language of the current cell
+otherwise. As a result, just calling `run_all()` will run all cells that match the language of the
+current cell.
+
+
+Here are some example run mappings:
+```lua
+local runner = require("quarto.runner")
+vim.keymap.set("n", "<localleader>rc", runner.run_cell, { desc = "run cell", silent = true })
+vim.keymap.set("n", "<localleader>ra", runner.run_above, { desc = "run cell and above", silent = true })
+vim.keymap.set("n", "<localleader>rA", runner.run_all, { desc = "run all cells", silent = true })
+vim.keymap.set("n", "<localleader>rl", runner.run_line, { desc = "run line", silent = true })
+vim.keymap.set("v", "<localleader>r", runner.run_range, { desc = "run line", silent = true })
+vim.keymap.set("n", "<localleader>RA", function()
+  runner.run_all(true)
+end, { desc = "run all cells of all languages", silent = true })
+```
+
+
 ## Available Commands
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It will be merged with the default options, which are shown below in the example
 If you want to use the defaults, simply call `setup` without arguments or with an empty table.
 
 ```lua
-require'quarto'.setup{
+require('quarto').setup({
   debug = false,
   closePreviewOnExit = true,
   lspFeatures = {
@@ -76,6 +76,13 @@ require'quarto'.setup{
     diagnostics = {
       enabled = true,
       triggers = { "BufWritePost" }
+    },
+    codeRunner = {
+      enabled = false,
+      default_method = nil, -- 'molten-nvim' or 'vim-slime'
+      ft_runners = {}, -- filetype to runner, ie. `{ python = "molten-nvim" }`.
+                     -- Takes precedence over `default_method`
+      never_run = { "yaml" }, -- filetypes which are never sent to a code runner
     },
     completion = {
       enabled = true,
@@ -87,7 +94,7 @@ require'quarto'.setup{
     rename = '<leader>lR',
     references = 'gr',
   }
-}
+})
 ```
 
 ### Preview
@@ -101,9 +108,9 @@ QuartoPreview
 or access the function from lua, e.g. to create a keybinding:
 
 ```lua
-local quarto = require'quarto'
+local quarto = require('quarto')
 quarto.setup()
-vim.keymap.set('n', '<leader>qp', quarto.quartoPreview, {silent = true, noremap = true})
+vim.keymap.set('n', '<leader>qp', quarto.quartoPreview, { silent = true, noremap = true })
 ```
 
 Then use the keyboard shortcut to open `quarto preview` for the current file or project in the active working directory in the neovim integrated terminal in a new tab.
@@ -154,13 +161,13 @@ You can now also enable other lsp features, such as the show hover function
 and shortcut, independent of showing diagnostics by enabling lsp features
 but not enabling diagnostics.
 
-### Other edgecases
+### Other Edge Cases
 
 Other languages might have similar issues (e.g. I see a lot of warnings about whitespace when activating diagnostics with `lua`).
 If you come across them and have a fix, I will be very happy about a pull request!
 Or, what might ultimately be the cleaner way of documenting language specific issues, an entry in the [wiki](https://github.com/quarto-dev/quarto-nvim/wiki).
 
-## Available Commnds
+## Available Commands
 
 ```vim
 QuartoPreview
@@ -169,8 +176,11 @@ QuartoHelp <..>
 QuartoActivate
 QuartoDiagnostics
 QuartoHover
+QuartoSend
 QuartoSendAbove
+QuartoSendBelow
 QuartoSendAll
+QuartoSendLine
 ```
 
 ## Recommended Plugins

--- a/ftplugin/quarto.lua
+++ b/ftplugin/quarto.lua
@@ -1,6 +1,6 @@
 vim.b.slime_cell_delimiter = "```"
 
-local config = require("quarto.config").get_config()
+local config = require("quarto.config").config
 local quarto = require("quarto")
 
 local function set_keymaps()

--- a/ftplugin/quarto.lua
+++ b/ftplugin/quarto.lua
@@ -1,22 +1,23 @@
 vim.b.slime_cell_delimiter = "```"
 
-local quarto = require 'quarto'
+local config = require("quarto.config").get_config()
+local quarto = require("quarto")
 
 local function set_keymaps()
   local b = vim.api.nvim_get_current_buf()
   local function set(lhs, rhs)
-    vim.api.nvim_buf_set_keymap(b, 'n', lhs, rhs, { silent = true, noremap = true })
+    vim.api.nvim_buf_set_keymap(b, "n", lhs, rhs, { silent = true, noremap = true })
   end
-  set(quarto.config.keymap.definition, ":lua require'otter'.ask_definition()<cr>")
-  set(quarto.config.keymap.type_definition, ":lua require'otter'.ask_type_definition()<cr>")
-  set(quarto.config.keymap.hover, ":lua require'otter'.ask_hover()<cr>")
-  set(quarto.config.keymap.rename, ":lua require'otter'.ask_rename()<cr>")
-  set(quarto.config.keymap.references, ":lua require'otter'.ask_references()<cr>")
-  set(quarto.config.keymap.document_symbols, ":lua require'otter'.ask_document_symbols()<cr>")
-  set(quarto.config.keymap.format, ":lua require'otter'.ask_format()<cr>")
+  set(config.keymap.definition, ":lua require'otter'.ask_definition()<cr>")
+  set(config.keymap.type_definition, ":lua require'otter'.ask_type_definition()<cr>")
+  set(config.keymap.hover, ":lua require'otter'.ask_hover()<cr>")
+  set(config.keymap.rename, ":lua require'otter'.ask_rename()<cr>")
+  set(config.keymap.references, ":lua require'otter'.ask_references()<cr>")
+  set(config.keymap.document_symbols, ":lua require'otter'.ask_document_symbols()<cr>")
+  set(config.keymap.format, ":lua require'otter'.ask_format()<cr>")
 end
 
-if quarto.config.lspFeatures.enabled then
+if config.lspFeatures.enabled then
   quarto.activate()
   set_keymaps()
   -- set the keymap again if a language server attaches
@@ -31,7 +32,7 @@ if quarto.config.lspFeatures.enabled then
   -- <https://github.com/neovim/neovim/blob/d0d132fbd055834cbecb3d4e3a123a6ea8f099ec/runtime/lua/vim/lsp.lua#L1702-L1711>
   vim.api.nvim_create_autocmd("LspAttach", {
     buffer = vim.api.nvim_get_current_buf(),
-    group = vim.api.nvim_create_augroup('QuartoKeymapSetup', {}),
+    group = vim.api.nvim_create_augroup("QuartoKeymapSetup", {}),
     callback = set_keymaps,
   })
 end

--- a/lua/quarto/config.lua
+++ b/lua/quarto/config.lua
@@ -17,7 +17,7 @@ M.defaultConfig = {
   },
   codeRunner = {
     enabled = false,
-    default_method = nil, -- 'molten-nvim' or 'vim-slime'
+    default_method = nil, -- 'molten' or 'slime'
     ft_runners = {}, -- filetype to runner, ie. `{ python = "molten-nvim" }`.
                      -- Takes precedence over `default_method`
     never_run = { "yaml" }, -- filetypes which are never sent to a code runner
@@ -34,6 +34,10 @@ M.defaultConfig = {
 }
 
 -- use defaultConfig if not setup
-M.config = M.defaultConfig
+M.config = M.config or M.defaultConfig
+
+M.get_config = function()
+  return M.config
+end
 
 return M

--- a/lua/quarto/config.lua
+++ b/lua/quarto/config.lua
@@ -17,8 +17,8 @@ M.defaultConfig = {
   },
   codeRunner = {
     enabled = false,
-    default_method = nil, -- 'molten' or 'slime'
-    ft_runners = {}, -- filetype to runner, ie. `{ python = "molten-nvim" }`.
+    default_method = nil, -- "molten" or "slime"
+    ft_runners = {}, -- filetype to runner, ie. `{ python = "molten" }`.
                      -- Takes precedence over `default_method`
     never_run = { "yaml" }, -- filetypes which are never sent to a code runner
   },
@@ -35,9 +35,5 @@ M.defaultConfig = {
 
 -- use defaultConfig if not setup
 M.config = M.config or M.defaultConfig
-
-M.get_config = function()
-  return M.config
-end
 
 return M

--- a/lua/quarto/config.lua
+++ b/lua/quarto/config.lua
@@ -1,0 +1,42 @@
+local M = {}
+
+M.defaultConfig = {
+  debug = false,
+  closePreviewOnExit = true,
+  lspFeatures = {
+    enabled = true,
+    chunks = "curly",
+    languages = { "r", "python", "julia", "bash", "html" },
+    diagnostics = {
+      enabled = true,
+      triggers = { "BufWritePost" },
+    },
+    completion = {
+      enabled = true,
+    },
+  },
+  codeRunner = {
+    enabled = true,
+    ft_runners = {}, -- filetype to runner, allowing different runners for different languages
+    never_run = { "yaml" }, -- filetypes to never try to run
+    default_method = "molten-nvim", -- or 'yarepl' or 'vim-slime'
+    -- TODO: implement auto target switching
+    -- auto_target_switching = false, -- automatically try to send the code to the correct place instead of asking every time
+    -- this should be implemented by just remembering where each language was sent, and not
+    -- prompting the user every time
+  },
+  keymap = {
+    hover = "K",
+    definition = "gd",
+    type_definition = "gD",
+    rename = "<leader>lR",
+    format = "<leader>lf",
+    references = "gr",
+    document_symbols = "gS",
+  },
+}
+
+-- use defaultConfig if not setup
+M.config = M.defaultConfig
+
+return M

--- a/lua/quarto/config.lua
+++ b/lua/quarto/config.lua
@@ -16,14 +16,11 @@ M.defaultConfig = {
     },
   },
   codeRunner = {
-    enabled = true,
-    ft_runners = {}, -- filetype to runner, allowing different runners for different languages
-    never_run = { "yaml" }, -- filetypes to never try to run
-    default_method = "molten-nvim", -- or 'yarepl' or 'vim-slime'
-    -- TODO: implement auto target switching
-    -- auto_target_switching = false, -- automatically try to send the code to the correct place instead of asking every time
-    -- this should be implemented by just remembering where each language was sent, and not
-    -- prompting the user every time
+    enabled = false,
+    default_method = nil, -- 'molten-nvim' or 'vim-slime'
+    ft_runners = {}, -- filetype to runner, ie. `{ python = "molten-nvim" }`.
+                     -- Takes precedence over `default_method`
+    never_run = { "yaml" }, -- filetypes which are never sent to a code runner
   },
   keymap = {
     hover = "K",

--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -1,38 +1,9 @@
 local M = {}
 local api = vim.api
+local cfg = require("quarto.config")
 local otter = require("otter")
-local otterkeeper = require("otter.keeper")
 local tools = require("quarto.tools")
 local util = require("lspconfig.util")
-
-M.defaultConfig = {
-  debug = false,
-  closePreviewOnExit = true,
-  lspFeatures = {
-    enabled = true,
-    chunks = "curly",
-    languages = { "r", "python", "julia", "bash", "html" },
-    diagnostics = {
-      enabled = true,
-      triggers = { "BufWritePost" },
-    },
-    completion = {
-      enabled = true,
-    },
-  },
-  keymap = {
-    hover = "K",
-    definition = "gd",
-    type_definition = "gD",
-    rename = "<leader>lR",
-    format = "<leader>lf",
-    references = "gr",
-    document_symbols = "gS",
-  },
-}
-
--- use defaultConfig if not setup
-M.config = M.defaultConfig
 
 function M.quartoPreview(opts)
   opts = opts or {}
@@ -73,12 +44,12 @@ function M.quartoPreview(opts)
   vim.cmd("tabprevious")
   api.nvim_buf_set_var(0, "quartoOutputBuf", quartoOutputBuf)
 
-  if not M.config then
+  if not cfg.config then
     return
   end
 
   -- close preview terminal on exit of the quarto buffer
-  if M.config.closePreviewOnExit then
+  if cfg.config.closePreviewOnExit then
     api.nvim_create_autocmd({ "QuitPre", "WinClosed" }, {
       buffer = api.nvim_get_current_buf(),
       group = api.nvim_create_augroup("quartoPreview", {}),
@@ -121,7 +92,7 @@ end
 
 M.activate = function()
   local tsquery = nil
-  if M.config.lspFeatures.chunks == "curly" then
+  if cfg.config.lspFeatures.chunks == "curly" then
     tsquery = [[
       (fenced_code_block
       (info_string
@@ -138,95 +109,25 @@ M.activate = function()
       ]]
   end
   otter.activate(
-    M.config.lspFeatures.languages,
-    M.config.lspFeatures.completion.enabled,
-    M.config.lspFeatures.diagnostics.enabled,
+    cfg.config.lspFeatures.languages,
+    cfg.config.lspFeatures.completion.enabled,
+    cfg.config.lspFeatures.diagnostics.enabled,
     tsquery
   )
 end
 
 -- setup
 M.setup = function(opt)
-  M.config = vim.tbl_deep_extend("force", M.defaultConfig, opt or {})
+  cfg.config = vim.tbl_deep_extend("force", cfg.defaultConfig, opt or {})
 end
 
-local function concat(ls)
-  if not (type(ls) == "table") then
-    return ls .. "\n\n"
-  end
-  local s = ""
-  for _, l in ipairs(ls) do
-    if l ~= "" then
-      s = s .. "\n" .. l
-    end
-  end
-  return s .. "\n"
-end
-
-local function send(lines)
-  lines = concat(lines)
-  local success, yarepl = pcall(require, "yarepl")
-  if success then
-    yarepl._send_strings(0)
-  else
-    vim.fn["slime#send"](lines)
-    if success then
-      vim.fn.notify("Install a REPL code sending plugin to use this feature. Options are yarepl.nvim and vim-slim.")
-    end
-  end
-end
-
-M.quartoSend = function()
-  local lines = otterkeeper.get_language_lines_around_cursor()
-  if lines == nil then
-    print("No code chunk detected around cursor")
-    return
-  end
-  send(lines)
-end
-
-M.quartoSendAbove = function()
-  local lines = otterkeeper.get_language_lines_to_cursor(true)
-  if lines == nil then
-    print(
-      "No code chunks found for the current language, which is detected based on the current code block. Is your cursor in a code block?"
-    )
-    return
-  end
-  send(lines)
-end
-
-M.quartoSendBelow = function()
-  local lines = otterkeeper.get_language_lines_from_cursor(true)
-  if lines == nil then
-    print(
-      "No code chunks found for the current language, which is detected based on the current code block. Is your cursor in a code block?"
-    )
-    return
-  end
-  send(lines)
-end
-
-M.quartoSendAll = function()
-  local lines = otterkeeper.get_language_lines(true)
-  if lines == nil then
-    print(
-      "No code chunks found for the current language, which is detected based on the current code block. Is your cursor in a code block?"
-    )
-    return
-  end
-  send(lines)
-end
-
-M.quartoSendRange = function()
-  local lines = otterkeeper.get_language_lines_in_visual_selection(true)
-  if lines == nil then
-    print(
-      "No code chunks found for the current language, which is detected based on the current code block. Is your cursor in a code block?"
-    )
-    return
-  end
-  send(lines)
-end
+-- setup top level run functions
+local runner = require("quarto.runner")
+M.quartoSend = runner.run_cell
+M.quartoSendAbove = runner.run_above
+M.quartoSendBelow = runner.run_below
+M.quartoSendAll = runner.run_all
+M.quartoSendRange = runner.run_range
+M.quartoSendLine = runner.run_line
 
 return M

--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -119,15 +119,18 @@ end
 -- setup
 M.setup = function(opt)
   cfg.config = vim.tbl_deep_extend("force", cfg.defaultConfig, opt or {})
+
+  if cfg.config.codeRunner.enabled then
+    -- setup top level run functions
+    local runner = require("quarto.runner")
+    M.quartoSend = runner.run_cell
+    M.quartoSendAbove = runner.run_above
+    M.quartoSendBelow = runner.run_below
+    M.quartoSendAll = runner.run_all
+    M.quartoSendRange = runner.run_range
+    M.quartoSendLine = runner.run_line
+  end
 end
 
--- setup top level run functions
-local runner = require("quarto.runner")
-M.quartoSend = runner.run_cell
-M.quartoSendAbove = runner.run_above
-M.quartoSendBelow = runner.run_below
-M.quartoSendAll = runner.run_all
-M.quartoSendRange = runner.run_range
-M.quartoSendLine = runner.run_line
 
 return M

--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -129,6 +129,14 @@ M.setup = function(opt)
     M.quartoSendAll = runner.run_all
     M.quartoSendRange = runner.run_range
     M.quartoSendLine = runner.run_line
+
+    -- setup run user commands
+    api.nvim_create_user_command("QuartoSend", runner.run_cell, {})
+    api.nvim_create_user_command("QuartoSendAbove", runner.run_above, {})
+    api.nvim_create_user_command("QuartoSendBelow", runner.run_below, {})
+    api.nvim_create_user_command("QuartoSendAll", runner.run_all, {})
+    api.nvim_create_user_command("QuartoSendRange", runner.run_range, { range = 2 })
+    api.nvim_create_user_command("QuartoSendLine", runner.run_line, {})
   end
 end
 

--- a/lua/quarto/runner.lua
+++ b/lua/quarto/runner.lua
@@ -61,7 +61,7 @@ end
 ---@field to table<number>
 
 ---@class CodeCell
----@field lang string
+---@field lang string?
 ---@field text table<string>
 ---@field range Range
 
@@ -148,7 +148,6 @@ Runner.run_all = function(multi_lang)
 end
 
 Runner.run_line = function()
-  print("run line")
   local buf = vim.api.nvim_get_current_buf()
   local lang = otterkeeper.get_current_language_context()
   local pos = vim.api.nvim_win_get_cursor(0)
@@ -179,7 +178,6 @@ Runner.run_range = function()
 
   if vstart and vend then
     local range = { from = { vstart[2] - 1, vstart[1] }, to = { vend[2], vend[1] } }
-    P(range)
     send({ lang = otterkeeper.get_current_language_context(), range = range, text = lines })
   else
     print("No visual selection")

--- a/lua/quarto/runner.lua
+++ b/lua/quarto/runner.lua
@@ -1,0 +1,189 @@
+--- Code runner, configurable to use different engines.
+local Runner = {}
+
+local otterkeeper = require("otter.keeper")
+local config = require("quarto.config").config
+
+local no_code_found =
+  "No code chunks found for the current language, which is detected based on the current code block. Is your cursor in a code block?"
+
+local function concat(ls)
+  if type(ls) ~= "table" then
+    return ls .. "\n\n"
+  end
+  local s = ""
+  for _, l in ipairs(ls) do
+    if l ~= "" then
+      s = s .. "\n" .. l
+    end
+  end
+  return s .. "\n"
+end
+
+local function overlaps_range(range, other)
+  return range.from[1] <= other.to[1] and other.from[1] <= range.to[1]
+end
+
+---pull the code chunks that overlap the given range, removes cells with a language that's in the
+---ignore list
+---@param lang string?
+---@param code_chunks table<string, CodeCell>
+---@param range Range
+---@return table<CodeCell>
+local function extract_code_cells_in_range(lang, code_chunks, range)
+  local chunks = {}
+
+  if lang then
+    for _, chunk in ipairs(code_chunks[lang]) do
+      if overlaps_range(chunk.range, range) then
+        table.insert(chunks, chunk)
+      end
+    end
+  else
+    for l, lang_chunks in pairs(code_chunks) do
+      if vim.tbl_contains(config.codeRunner.never_run, l) then
+        goto continue
+      end
+      for _, chunk in ipairs(lang_chunks) do
+        if overlaps_range(chunk.range, range) then
+          table.insert(chunks, chunk)
+        end
+      end
+      ::continue::
+    end
+  end
+
+  return chunks
+end
+
+---@class Range
+---@field from table<number>
+---@field to table<number>
+
+---@class CodeCell
+---@field lang string
+---@field text table<string>
+---@field range Range
+
+---send code cell to the correct repl based on language, and user configuration
+---@param cell CodeCell
+---@param opts table?
+local function send(cell, opts)
+  opts = opts or { ignore_cols = false }
+  local runner = config.codeRunner.default_method
+  local ft_runners = config.codeRunner.ft_runners
+  if cell.lang ~= nil and ft_runners[cell.lang] ~= nil then
+    runner = ft_runners[cell.lang]
+  end
+
+  if runner == "molten-nvim" then
+    local range = cell.range
+    if opts.ignore_cols then
+      vim.fn.MoltenEvaluateRange(range.from[1] + 1, range.to[1])
+    else
+      vim.fn.MoltenEvaluateRange(range.from[1] + 1, range.to[1], range.from[2] + 1, range.to[2] + 1)
+    end
+  elseif runner == "vim-slime" then
+    local text_lines = concat(cell.text)
+    vim.fn["slime#send"](text_lines)
+  else
+    vim.notify("[Quarto] send called with an unrecognized runner", vim.log.levels.ERROR)
+  end
+end
+
+---run the code chunks for the given language that overlap the given range
+---@param range Range a range, for with any overlapping code cells are run
+---@param multi_lang boolean?
+local function run(range, multi_lang)
+  local buf = vim.api.nvim_get_current_buf()
+  local lang = nil
+  if multi_lang then
+    lang = otterkeeper.get_current_language_context()
+  end
+
+  otterkeeper.sync_raft(buf)
+  local chunks = otterkeeper._otters_attached[buf].code_chunks
+
+  local filtered = extract_code_cells_in_range(lang, chunks, range)
+
+  if #filtered == 0 then
+    print(no_code_found)
+    return
+  end
+  for _, chunk in ipairs(filtered) do
+    send(chunk, { ignore_cols = true })
+  end
+end
+
+---@param multi_lang boolean?
+Runner.run_cell = function(multi_lang)
+  local y = vim.api.nvim_win_get_cursor(0)[1] - 1
+  local r = { y, 0 }
+  local range = { from = r, to = r }
+
+  run(range, multi_lang)
+end
+
+---@param multi_lang boolean?
+Runner.run_above = function(multi_lang)
+  local y = vim.api.nvim_win_get_cursor(0)[1] - 1
+  local range = { from = { 0, 0 }, to = { y, 0 } }
+
+  run(range, multi_lang)
+end
+
+---@param multi_lang boolean?
+Runner.run_below = function(multi_lang)
+  local y = vim.api.nvim_win_get_cursor(0)[1] - 1
+  local range = { from = { y, 0 }, to = { math.huge, 0 } }
+
+  run(range, multi_lang)
+end
+
+---@param multi_lang boolean?
+Runner.run_all = function(multi_lang)
+  local range = { from = { 0, 0 }, to = { math.huge, 0 } }
+
+  run(range, multi_lang)
+end
+
+Runner.run_line = function()
+  print("run line")
+  local buf = vim.api.nvim_get_current_buf()
+  local lang = otterkeeper.get_current_language_context()
+  local pos = vim.api.nvim_win_get_cursor(0)
+
+  ---@type CodeCell
+  local cell = {
+    lang = lang,
+    range = { from = { pos[1] - 1, 0 }, to = { pos[1], 0 } },
+    text = { vim.api.nvim_buf_get_lines(buf, pos[1] - 1, pos[1], false) },
+  }
+
+  send(cell, { ignore_cols = true })
+end
+
+-- NOTE: This function will not work the same with molten as it does with slime. Generally, code
+-- runners which run code based on the CodeCell range field, will not work when the user selects
+-- code across cells. But it will work if a selection is entirely within a cell.
+-- Also: This function cannot run multiple languages at once.
+Runner.run_range = function()
+  local lines = otterkeeper.get_language_lines_in_visual_selection(true)
+  if lines == nil then
+    print(no_code_found)
+    return
+  end
+
+  local vstart = vim.fn.getpos("'<")
+  local vend = vim.fn.getpos("'>")
+
+  if vstart and vend then
+    local range = { from = { vstart[2] - 1, vstart[1] }, to = { vend[2], vend[1] } }
+    P(range)
+    send({ lang = otterkeeper.get_current_language_context(), range = range, text = lines })
+  else
+    print("No visual selection")
+  end
+end
+
+return Runner

--- a/lua/quarto/runner/init.lua
+++ b/lua/quarto/runner/init.lua
@@ -85,6 +85,11 @@ local function run(range, multi_lang)
   end
 
   otterkeeper.sync_raft(buf)
+  local oa = otterkeeper._otters_attached[buf]
+  if oa == nil then
+    vim.notify("[Quarto] it seems that the code runner isn't initialized for this buffer.", vim.log.levels.ERROR)
+    return
+  end
   local chunks = otterkeeper._otters_attached[buf].code_chunks
 
   local filtered = extract_code_cells_in_range(lang, chunks, range)

--- a/lua/quarto/runner/init.lua
+++ b/lua/quarto/runner/init.lua
@@ -2,7 +2,7 @@
 local Runner = {}
 
 local otterkeeper = require("otter.keeper")
-local get_config = require("quarto.config").get_config
+local config = require("quarto.config").config
 
 local no_code_found =
   "No code chunks found for the current language, which is detected based on the current code block. Is your cursor in a code block?"
@@ -28,7 +28,7 @@ local function extract_code_cells_in_range(lang, code_chunks, range)
     end
   else
     for l, lang_chunks in pairs(code_chunks) do
-      if vim.tbl_contains(get_config().codeRunner.never_run, l) then
+      if vim.tbl_contains(config.codeRunner.never_run, l) then
         goto continue
       end
       for _, chunk in ipairs(lang_chunks) do
@@ -61,8 +61,8 @@ end
 ---@param opts table?
 local function send(cell, opts)
   opts = opts or { ignore_cols = false }
-  local runner = get_config().codeRunner.default_method
-  local ft_runners = get_config().codeRunner.ft_runners
+  local runner = config.codeRunner.default_method
+  local ft_runners = config.codeRunner.ft_runners
   if cell.lang ~= nil and ft_runners[cell.lang] ~= nil then
     runner = ft_runners[cell.lang]
   end

--- a/lua/quarto/runner/molten.lua
+++ b/lua/quarto/runner/molten.lua
@@ -1,0 +1,16 @@
+---Run the code cell with molten
+---@param cell CodeCell
+---@param ignore_cols boolean
+local function run(cell, ignore_cols)
+  local range = cell.range
+  if ignore_cols then
+    vim.fn.MoltenEvaluateRange(range.from[1] + 1, range.to[1])
+  else
+    vim.fn.MoltenEvaluateRange(range.from[1] + 1, range.to[1], range.from[2] + 1, range.to[2] + 1)
+  end
+end
+
+---@class CodeRunner
+local M = { run = run }
+
+return M

--- a/lua/quarto/runner/slime.lua
+++ b/lua/quarto/runner/slime.lua
@@ -1,0 +1,14 @@
+local concat = require('quarto.tools').concat
+
+---Run the code cell with molten
+---@param cell CodeCell
+---@param _ boolean
+local function run(cell, _)
+  local text_lines = concat(cell.text)
+  vim.fn["slime#send"](text_lines)
+end
+
+---@class CodeRunner
+local M = { run = run }
+
+return M

--- a/lua/quarto/tools.lua
+++ b/lua/quarto/tools.lua
@@ -14,4 +14,17 @@ M.replace_header_div = function(response)
   return response
 end
 
+M.concat = function(ls)
+  if type(ls) ~= "table" then
+    return ls .. "\n\n"
+  end
+  local s = ""
+  for _, l in ipairs(ls) do
+    if l ~= "" then
+      s = s .. "\n" .. l
+    end
+  end
+  return s .. "\n"
+end
+
 return M

--- a/plugin/quarto.lua
+++ b/plugin/quarto.lua
@@ -20,12 +20,3 @@ api.nvim_create_user_command("QuartoClosePreview", quarto.quartoClosePreview, {}
 api.nvim_create_user_command("QuartoActivate", quarto.activate, {})
 api.nvim_create_user_command("QuartoHelp", quarto.searchHelp, { nargs = 1 })
 api.nvim_create_user_command("QuartoHover", ':require"otter".ask_hover()<cr>', {})
-
-if require('quarto.config').get_config().codeRunner.enabled then
-  api.nvim_create_user_command("QuartoSend", quarto.quartoSend, {})
-  api.nvim_create_user_command("QuartoSendAbove", quarto.quartoSendAbove, {})
-  api.nvim_create_user_command("QuartoSendBelow", quarto.quartoSendBelow, {})
-  api.nvim_create_user_command("QuartoSendAll", quarto.quartoSendAll, {})
-  api.nvim_create_user_command("QuartoSendRange", quarto.quartoSendRange, { range = 2 })
-  api.nvim_create_user_command("QuartoSendLine", quarto.quartoSendLine, {})
-end

--- a/plugin/quarto.lua
+++ b/plugin/quarto.lua
@@ -1,6 +1,5 @@
 if vim.fn.has("nvim-0.9.0") ~= 1 then
-  local msg =
-  [[
+  local msg = [[
   quarto-dev/quarto-nvim and jmbuhr/otter.nvim require Neovim version >= 0.9.0 (https://github.com/neovim/neovim/releases/tag/stable).
   If you are unable to update Neovim, you can specify a specific version of the plugins involved instead of the latest stable version.
   How you do this will vary depending on your plugin manager, but you can see one example using `lazy.nvim` here:
@@ -13,16 +12,20 @@ if vim.fn.has("nvim-0.9.0") ~= 1 then
   return
 end
 
-local quarto = require 'quarto'
+local quarto = require("quarto")
 local api = vim.api
 
-api.nvim_create_user_command('QuartoPreview', quarto.quartoPreview, { nargs = '*' })
-api.nvim_create_user_command('QuartoClosePreview', quarto.quartoClosePreview, {})
-api.nvim_create_user_command('QuartoActivate', quarto.activate, {})
-api.nvim_create_user_command('QuartoHelp', quarto.searchHelp, { nargs = 1 })
-api.nvim_create_user_command('QuartoHover', ':require"otter".ask_hover()<cr>', {})
-api.nvim_create_user_command('QuartoSend', quarto.quartoSend, {})
-api.nvim_create_user_command('QuartoSendAbove', quarto.quartoSendAbove, {})
-api.nvim_create_user_command('QuartoSendBelow', quarto.quartoSendBelow, {})
-api.nvim_create_user_command('QuartoSendAll', quarto.quartoSendAll, {})
-api.nvim_create_user_command('QuartoSendRange', quarto.quartoSendRange, { range = 2 })
+api.nvim_create_user_command("QuartoPreview", quarto.quartoPreview, { nargs = "*" })
+api.nvim_create_user_command("QuartoClosePreview", quarto.quartoClosePreview, {})
+api.nvim_create_user_command("QuartoActivate", quarto.activate, {})
+api.nvim_create_user_command("QuartoHelp", quarto.searchHelp, { nargs = 1 })
+api.nvim_create_user_command("QuartoHover", ':require"otter".ask_hover()<cr>', {})
+
+if require('quarto.config').get_config().codeRunner.enabled then
+  api.nvim_create_user_command("QuartoSend", quarto.quartoSend, {})
+  api.nvim_create_user_command("QuartoSendAbove", quarto.quartoSendAbove, {})
+  api.nvim_create_user_command("QuartoSendBelow", quarto.quartoSendBelow, {})
+  api.nvim_create_user_command("QuartoSendAll", quarto.quartoSendAll, {})
+  api.nvim_create_user_command("QuartoSendRange", quarto.quartoSendRange, { range = 2 })
+  api.nvim_create_user_command("QuartoSendLine", quarto.quartoSendLine, {})
+end


### PR DESCRIPTION
closes #93
closes #81 

### General notes
- I've pulled config out into it's own file
- The api hasn't changed, ie there are still `:QuartoSend` and `require('quarto').quartoSend()` functions (for now, thinking about removing the old lua functions), but there's now also `require('quarto.runner').run_cell(multi_lang: bool)` functions that give the user control over if the function runs multiple languages at once. I'm completely open to changing these function names if you want them to be more analogous to the current "send", "sendCell" etc.

#### Things that are working
- All of the 'old' code running functions
- a new `QuartoSendLine`
- configuring your code runner (currently the only options are Molten and Slime) with default and on a per language basis.
- excluding some languages from being run ever (default to just ignore `yaml`)

#### More changes before this PR is ready
- [x] I'm definitely going to refactor the way code runners work so they each have their own file, and export a common table of functions that we can use to cleanup the send function a little.
- [x] README needs an update to talk about these changes.
- [x] config defaults should be changed so that code running doesn't work by default (b/c the user has to install another plugin for it to work)

#### Things I'm pushing off until a later PR
- auto target switching. This ended up being too much for right now. I think that I want to discuss what exactly this should look like more in depth. The challenge here I think will be handling different runners doing different things and provide a good UX for this
