### PR TITLE
Support Iron.nvim and user functions for sending code to REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ require('quarto').setup({
   },
   codeRunner = {
     enabled = false,
-    default_method = nil, -- 'molten' or 'slime'
+    default_method = nil, -- 'molten', 'slime', or 'iron'
     ft_runners = {}, -- filetype to runner, ie. `{ python = "molten" }`.
                      -- Takes precedence over `default_method`
     never_run = { "yaml" }, -- filetypes which are never sent to a code runner
@@ -176,6 +176,8 @@ will work with:
    kernel, renders output below each code cell, and optionally renders images in the terminal.
 2. [vim-slime](https://github.com/jpalardy/vim-slime) - a general purpose code runner with support
    for sending code to integrated nvim terminals, tmux panes, and many others.
+3. [iron.nvim](https://github.com/Vigemus/iron.nvim) - general purpose code runner and library for
+    within-neovim REPL interaction in splits or floating windows.
 
 I recommend picking a code runner, setting it up based on its README, and then coming back
 to this point to learn how Quarto will augment that code runner.

--- a/lua/quarto/config.lua
+++ b/lua/quarto/config.lua
@@ -17,7 +17,7 @@ M.defaultConfig = {
   },
   codeRunner = {
     enabled = false,
-    default_method = nil, -- "molten" or "slime"
+    default_method = nil, -- "molten", "slime", or "iron"
     ft_runners = {}, -- filetype to runner, ie. `{ python = "molten" }`.
                      -- Takes precedence over `default_method`
     never_run = { "yaml" }, -- filetypes which are never sent to a code runner

--- a/lua/quarto/runner/init.lua
+++ b/lua/quarto/runner/init.lua
@@ -67,7 +67,12 @@ local function send(cell, opts)
     runner = ft_runners[cell.lang]
   end
 
-  if runner ~= nil then
+  -- if user passes a fn to config.codeRunner.default_method, we use that.
+  -- (this also means fns are allowed as values in ft_runners)
+  -- otherwise we lookup a string for pre-packaged runner function, e.g. "molten"
+  if type(runner) == "function" then
+        runner(cell, opts.ignore_cols)
+  elseif type(runner) == "string" then
     require("quarto.runner." .. runner).run(cell, opts.ignore_cols)
   else
     vim.notify("[Quarto] couldn't find appropriate code runner for language: " .. cell.lang, vim.log.levels.ERROR)

--- a/lua/quarto/runner/init.lua
+++ b/lua/quarto/runner/init.lua
@@ -155,7 +155,7 @@ Runner.run_line = function()
   send(cell, { ignore_cols = true })
 end
 
--- NOTE: This function will not work the same with molten as it does with slime. Generally, code
+-- NOTE: This function will not work the same with molten as it does with slime/iron. Generally, code
 -- runners which run code based on the CodeCell range field, will not work when the user selects
 -- code across cells. But it will work if a selection is entirely within a cell.
 -- Also: This function cannot run multiple languages at once.

--- a/lua/quarto/runner/iron.lua
+++ b/lua/quarto/runner/iron.lua
@@ -1,0 +1,21 @@
+local concat = require('quarto.tools').concat
+local iron_send = require("iron.core").send
+
+---Run the code cell with iron
+---@param cell CodeCell
+---@param _ boolean
+local function run(cell, _)
+  local text_lines = concat(cell.text)
+  local lang = cell.lang or "quarto"
+  -- forward to iron.send
+  -- first arg is filetype. if not supplied, iron.core.send would infer "quarto".
+  -- Iron lets the user map a filetype to a repl binary, e.g. {"python" = "ipython", "r" = "radian"}
+  -- so we can pass the cell.lang to get the same feel from a .qmd file.
+  iron_send(lang, text_lines)
+end
+
+---@class CodeRunner
+local M = { run = run }
+
+return M
+

--- a/lua/quarto/runner/slime.lua
+++ b/lua/quarto/runner/slime.lua
@@ -1,6 +1,6 @@
 local concat = require('quarto.tools').concat
 
----Run the code cell with molten
+---Run the code cell with slime
 ---@param cell CodeCell
 ---@param _ boolean
 local function run(cell, _)


### PR DESCRIPTION
Hi folks, thanks for this package.

When I was trying to set it up for myself, I wanted to hook it into my REPL workflow that uses [`iron.nvim`](https://github.com/Vigemus/iron.nvim) instead of converting to molten or slime. It seemed easy enough to add an `iron.lua` runner file, but more generally it seems like the user should be able to pass any fn they want from their config. So this PR does both:

1. Provides cursory support for Iron REPLs plugin.
2. Slightly generalizes the code-sending internals to allow the user to pass any function as their code-runner.

If you don't want to support Iron I would at least encourage you to support functions in the `default_method` config field. It's nicer than having the user hack into the pkg tables to override the entire send() function.

Thanks, eager to see what you think (fair warning I'm a lua noob and not too familiar with either quarto-nvim or iron code bases).

