### PR TITLE
fix: QuartoHover user function

### DIFF
--- a/plugin/quarto.lua
+++ b/plugin/quarto.lua
@@ -19,4 +19,4 @@ api.nvim_create_user_command("QuartoPreview", quarto.quartoPreview, { nargs = "*
 api.nvim_create_user_command("QuartoClosePreview", quarto.quartoClosePreview, {})
 api.nvim_create_user_command("QuartoActivate", quarto.activate, {})
 api.nvim_create_user_command("QuartoHelp", quarto.searchHelp, { nargs = 1 })
-api.nvim_create_user_command("QuartoHover", ':require"otter".ask_hover()<cr>', {})
+api.nvim_create_user_command("QuartoHover", ':lua require"otter".ask_hover()<cr>', {})


### PR DESCRIPTION
In testing my otter changes using Quarto, I found out that the `:QuartoHover` command is broken
