### PR TITLE
Fix: Replace term:// with termopen() to resolve wildcard expansion error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ example*.hs
 examples/*.docx
 examples/*.html
 examples/*.pdf
+.DS_Store

--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -8,53 +8,40 @@ function M.quartoPreview(opts)
   opts = opts or {}
   local args = opts.args or ''
 
-  -- find root directory / check if it is a project
+  -- Find root directory / check if it is a project
   local buffer_path = api.nvim_buf_get_name(0)
   local root_dir = util.root_pattern '_quarto.yml'(buffer_path)
   local cmd
-  local mode
+
   if root_dir then
-    mode = 'project'
-    cmd = 'quarto preview' .. ' ' .. args
+    cmd = 'quarto preview ' .. args
   else
-    mode = 'file'
-    if vim.loop.os_uname().sysname == 'Windows_NT' then
-      cmd = 'quarto preview \\"' .. buffer_path .. '\\"' .. ' ' .. args
-    else
-      cmd = "quarto preview '" .. buffer_path .. "'" .. ' ' .. args
-    end
+    cmd = 'quarto preview ' .. vim.fn.shellescape(buffer_path) .. ' ' .. args
   end
 
-  local quarto_extensions = { '.qmd', '.Rmd', '.ipynb', '.md' }
-  local file_extension = buffer_path:match '^.+(%..+)$'
-  if mode == 'file' and not file_extension then
-    vim.notify 'Not in a file. exiting.'
-    return
-  end
-  if mode == 'file' and not tools.contains(quarto_extensions, file_extension) then
-    vim.notify('Not a quarto file, ends in ' .. file_extension .. ' exiting.')
-    return
-  end
+  -- Open a new tab for the terminal
+  vim.cmd('tabedit')
+  local term_buf = vim.api.nvim_get_current_buf()
 
-  -- run command in embedded terminal
-  -- in a new tab and go back to the buffer
-  vim.cmd('tabedit term://' .. cmd)
-  local quartoOutputBuf = vim.api.nvim_get_current_buf()
-  vim.cmd 'tabprevious'
-  api.nvim_buf_set_var(0, 'quartoOutputBuf', quartoOutputBuf)
+  vim.fn.termopen(cmd, {
+    on_exit = function(_, exit_code, _)
+      if exit_code ~= 0 then
+        vim.notify("Quarto preview exited with code " .. exit_code, vim.log.levels.ERROR)
+      end
+    end,
+  })
 
-  if not cfg.config then
-    return
-  end
+  -- Store the terminal buffer
+  api.nvim_buf_set_var(0, 'quartoOutputBuf', term_buf)
 
-  -- close preview terminal on exit of the quarto buffer
-  if cfg.config.closePreviewOnExit then
+  -- Close preview terminal on exit of the Quarto buffer
+  if cfg.config and cfg.config.closePreviewOnExit then
     api.nvim_create_autocmd({ 'QuitPre', 'WinClosed' }, {
       buffer = api.nvim_get_current_buf(),
       group = api.nvim_create_augroup('quartoPreview', {}),
       callback = function(_, _)
-        if api.nvim_buf_is_loaded(quartoOutputBuf) then
-          api.nvim_buf_delete(quartoOutputBuf, { force = true })
+        if api.nvim_buf_is_loaded(term_buf) then
+          api.nvim_buf_delete(term_buf, { force = true })
         end
       end,
     })


### PR DESCRIPTION
Hi,
This is my first time submitting a PR! 😊

While following along with the Quarto.nvim Kickstarter videos, I encountered the following error when attempting to preview a Quarto document:
```
E79: Cannot expand wildcards
```

I thought this was maybe down to my config, so i made a new appname and changed to the nvim-quarto-kickstarter and i got the error again, and i also found this error was reported in [Issue #143](https://github.com/quarto-dev/quarto-nvim/issues/143)

### **Proposed Fix:**  
I replaced the `term://` command invocation with `vim.fn.termopen()` to prevent the wildcard expansion issue. This change resolves the error and allows the Quarto preview to work as expected.

---

### **Behavioral Changes:**  
1. The Quarto preview command now successfully runs without triggering the wildcard expansion error.
2. After running the preview, Neovim switches to the new terminal tab. I'm unsure if this behavior is intended or if it needs further adjustment.

---

### **Additional Notes:**  
Here’s a vid of the current behavior after applying the fix:  
![video](https://github.com/user-attachments/assets/b46d0dda-8f1a-4af5-b5d1-435565e543be)

---

### **Testing:**  
- Tested on macOS using **Fish shell**
- The command now runs without issues  
- Further testing on Linux and Windows would be appreciated to ensure cross-platform compatibility.

---

### **Why This Fix Works:**  
- **`term://`** can lead to wildcard and quote expansion issues, especially in non-Bash shells like Fish.
- **`termopen()`** directly invokes the command without triggering shell-specific expansions, making it more robust across different environments.

---

Please let me know if any changes or additional information are needed. Thank you for your time!