### PR TITLE
fix: pass `root_dir` to preview for project type

### DIFF
--- a/lua/quarto/init.lua
+++ b/lua/quarto/init.lua
@@ -49,7 +49,7 @@ function M.quartoPreview(opts)
 
   if root_dir then
     mode = 'project'
-    cmd = 'quarto preview ' .. args
+    cmd = 'quarto preview ' .. vim.fn.shellescape(root_dir) .. ' ' .. args
   else
     mode = 'file'
     cmd = 'quarto preview ' .. vim.fn.shellescape(buffer_path) .. ' ' .. args


### PR DESCRIPTION
- this allows to preview projects, even if neovims cwd is not within the project directory